### PR TITLE
testthat/integration tests for 5 apps

### DIFF
--- a/001-hello/app.R
+++ b/001-hello/app.R
@@ -34,20 +34,15 @@ ui <- fluidPage(
 # Define server logic required to draw a histogram ----
 server <- function(input, output) {
 
-  # Histogram of the Old Faithful Geyser Data ----
-  # with requested number of bins
-  # This expression that generates a histogram is wrapped in a call
-  # to renderPlot to indicate that:
-  #
-  # 1. It is "reactive" and therefore should be automatically
-  #    re-executed when inputs (input$bins) change
-  # 2. Its output type is a plot
+  x <- faithful$waiting
+
+  bins <- reactive({
+    seq(min(x), max(x), length.out = input$bins + 1)
+  })
+
   output$distPlot <- renderPlot({
 
-    x    <- faithful$waiting
-    bins <- seq(min(x), max(x), length.out = input$bins + 1)
-
-    hist(x, breaks = bins, col = "#75AADB", border = "white",
+    hist(x, breaks = bins(), col = "#75AADB", border = "white",
          xlab = "Waiting time to next eruption (in mins)",
          main = "Histogram of waiting times")
 

--- a/001-hello/tests/testthat.R
+++ b/001-hello/tests/testthat.R
@@ -1,0 +1,9 @@
+library(testthat)
+library(shiny)
+
+test_that("reactives update", {
+  testServer({
+    session$setInputs(bins = 5)
+    expect_equal(bins(), seq(43, 96, length.out = 6))
+  })
+})

--- a/001-hello/tests/testthat.R
+++ b/001-hello/tests/testthat.R
@@ -1,9 +1,4 @@
 library(testthat)
 library(shiny)
 
-test_that("reactives update", {
-  testServer({
-    session$setInputs(bins = 5)
-    expect_equal(bins(), seq(43, 96, length.out = 6))
-  })
-})
+testthat::test_file("testthat/tests.R")

--- a/001-hello/tests/testthat/tests.R
+++ b/001-hello/tests/testthat/tests.R
@@ -1,0 +1,9 @@
+library(testthat)
+library(shiny)
+
+test_that("reactives update", {
+  testServer({
+    session$setInputs(bins = 5)
+    expect_equal(bins(), seq(43, 96, length.out = 6))
+  })
+})

--- a/005-sliders/tests/testthat.R
+++ b/005-sliders/tests/testthat.R
@@ -1,26 +1,4 @@
 library(testthat)
 library(shiny)
 
-test_that("inputs are stored", {
-  testServer({
-    session$setInputs(
-      integer = 593,
-      decimal = 0.6,
-      range = c(100,300),
-      format = 5000,
-      animation = 100
-    )
-
-    # The data frame should have these properties
-    df <- sliderValues()
-    expect_equal(nrow(df), 5)
-    expect_equal(ncol(df), 2)
-    expect_is(df$Value, "character")
-
-    # Updating an input should result in a new plot
-    plot1 <- output$values
-    session$setInputs(integer = 594)
-    plot2 <- output$values
-    expect_true(plot1 != plot2)
-  })
-})
+testthat::test_file("testthat/tests.R")

--- a/005-sliders/tests/testthat.R
+++ b/005-sliders/tests/testthat.R
@@ -1,0 +1,26 @@
+library(testthat)
+library(shiny)
+
+test_that("inputs are stored", {
+  testServer({
+    session$setInputs(
+      integer = 593,
+      decimal = 0.6,
+      range = c(100,300),
+      format = 5000,
+      animation = 100
+    )
+
+    # The data frame should have these properties
+    df <- sliderValues()
+    expect_equal(nrow(df), 5)
+    expect_equal(ncol(df), 2)
+    expect_is(df$Value, "character")
+
+    # Updating an input should result in a new plot
+    plot1 <- output$values
+    session$setInputs(integer = 594)
+    plot2 <- output$values
+    expect_true(plot1 != plot2)
+  })
+})

--- a/005-sliders/tests/testthat/tests.R
+++ b/005-sliders/tests/testthat/tests.R
@@ -1,0 +1,26 @@
+library(testthat)
+library(shiny)
+
+test_that("inputs are stored", {
+  testServer({
+    session$setInputs(
+      integer = 593,
+      decimal = 0.6,
+      range = c(100,300),
+      format = 5000,
+      animation = 100
+    )
+
+    # The data frame should have these properties
+    df <- sliderValues()
+    expect_equal(nrow(df), 5)
+    expect_equal(ncol(df), 2)
+    expect_is(df$Value, "character")
+
+    # Updating an input should result in a new plot
+    plot1 <- output$values
+    session$setInputs(integer = 594)
+    plot2 <- output$values
+    expect_true(plot1 != plot2)
+  })
+})

--- a/050-kmeans-example/tests/testthat.R
+++ b/050-kmeans-example/tests/testthat.R
@@ -1,16 +1,4 @@
 library(testthat)
 library(shiny)
 
-testServer({
-  test_that("it works", {
-    session$setInputs(
-      xcol = "Sepal.Length",
-      ycol = "Petal.Length",
-      clusters = 4
-    )
-    expect_equal(colnames(selectedData()), c("Sepal.Length", "Petal.Length"))
-    expect_equal(nrow(clusters()$centers), 4)
-    session$setInputs(clusters = 3)
-    expect_equal(nrow(clusters()$centers), 3)
-  })
-})
+testthat::test_file("testthat/tests.R")

--- a/050-kmeans-example/tests/testthat.R
+++ b/050-kmeans-example/tests/testthat.R
@@ -1,0 +1,16 @@
+library(testthat)
+library(shiny)
+
+testServer({
+  test_that("it works", {
+    session$setInputs(
+      xcol = "Sepal.Length",
+      ycol = "Petal.Length",
+      clusters = 4
+    )
+    expect_equal(colnames(selectedData()), c("Sepal.Length", "Petal.Length"))
+    expect_equal(nrow(clusters()$centers), 4)
+    session$setInputs(clusters = 3)
+    expect_equal(nrow(clusters()$centers), 3)
+  })
+})

--- a/050-kmeans-example/tests/testthat/tests.R
+++ b/050-kmeans-example/tests/testthat/tests.R
@@ -1,0 +1,16 @@
+library(testthat)
+library(shiny)
+
+testServer({
+  test_that("it works", {
+    session$setInputs(
+      xcol = "Sepal.Length",
+      ycol = "Petal.Length",
+      clusters = 4
+    )
+    expect_equal(colnames(selectedData()), c("Sepal.Length", "Petal.Length"))
+    expect_equal(nrow(clusters()$centers), 4)
+    session$setInputs(clusters = 3)
+    expect_equal(nrow(clusters()$centers), 3)
+  })
+})

--- a/119-namespaced-conditionalpanel-demo/app.R
+++ b/119-namespaced-conditionalpanel-demo/app.R
@@ -33,11 +33,9 @@ myPlotUI <- function(id, label = "My Plot") {
 }
 
 myPlot <- function(input, output, session, deviates) {
-  output$scatterPlot <- renderPlot({
-    x <- rnorm(input$n)
-    y <- rnorm(input$n)
-    plot(x, y)
-  })
+  x <- reactive(rnorm(input$n))
+  y <- reactive(rnorm(input$n))
+  output$scatterPlot <- renderPlot(plot(x(), y()))
 }
 
 server <- function(input, output) {

--- a/119-namespaced-conditionalpanel-demo/tests/testthat.R
+++ b/119-namespaced-conditionalpanel-demo/tests/testthat.R
@@ -1,4 +1,4 @@
 library(testthat)
 library(shiny)
 
-testthat::test_file("testthat/tests.R", env = environment())
+testthat::test_file("testthat/tests.R")

--- a/119-namespaced-conditionalpanel-demo/tests/testthat.R
+++ b/119-namespaced-conditionalpanel-demo/tests/testthat.R
@@ -1,0 +1,15 @@
+library(testthat)
+library(shiny)
+library(withr)
+
+# TODO Determine the ideal way for module-reliant test code to load an app
+with_dir(shiny:::findApp(), {
+  local({
+    source("app.R")
+    test_that("module works", {
+      testModule(myPlot, {
+        expect_true(TRUE)
+      })
+    })
+  })
+})

--- a/119-namespaced-conditionalpanel-demo/tests/testthat.R
+++ b/119-namespaced-conditionalpanel-demo/tests/testthat.R
@@ -1,4 +1,4 @@
 library(testthat)
 library(shiny)
 
-testthat::test_file("testthat/tests.R")
+testthat::test_file("testthat/tests.R", env = environment())

--- a/119-namespaced-conditionalpanel-demo/tests/testthat.R
+++ b/119-namespaced-conditionalpanel-demo/tests/testthat.R
@@ -1,15 +1,4 @@
 library(testthat)
 library(shiny)
-library(withr)
 
-# TODO Determine the ideal way for module-reliant test code to load an app
-with_dir(shiny:::findApp(), {
-  local({
-    source("app.R")
-    test_that("module works", {
-      testModule(myPlot, {
-        expect_true(TRUE)
-      })
-    })
-  })
-})
+testthat::test_file("testthat/tests.R")

--- a/119-namespaced-conditionalpanel-demo/tests/testthat/tests.R
+++ b/119-namespaced-conditionalpanel-demo/tests/testthat/tests.R
@@ -1,0 +1,15 @@
+library(testthat)
+library(shiny)
+library(withr)
+
+# TODO Determine the ideal way for module-reliant test code to load an app
+with_dir(shiny:::findApp(), {
+  local({
+    source("app.R")
+    test_that("module works", {
+      testModule(myPlot, {
+        expect_true(TRUE)
+      })
+    })
+  })
+})

--- a/119-namespaced-conditionalpanel-demo/tests/testthat/tests.R
+++ b/119-namespaced-conditionalpanel-demo/tests/testthat/tests.R
@@ -1,15 +1,8 @@
 library(testthat)
 library(shiny)
-library(withr)
 
-# TODO Determine the ideal way for module-reliant test code to load an app
-with_dir(shiny:::findApp(), {
-  local({
-    source("app.R")
-    test_that("module works", {
-      testModule(myPlot, {
-        expect_true(TRUE)
-      })
-    })
+test_that("module works", {
+  testModule(myPlot, {
+    expect_true(TRUE)
   })
 })

--- a/119-namespaced-conditionalpanel-demo/tests/testthat/tests.R
+++ b/119-namespaced-conditionalpanel-demo/tests/testthat/tests.R
@@ -1,8 +1,15 @@
 library(testthat)
 library(shiny)
+library(withr)
 
-test_that("module works", {
-  testModule(myPlot, {
-    expect_true(TRUE)
+# TODO Determine the ideal way for module-reliant test code to load an app
+with_dir(shiny:::findApp(), {
+  local({
+    source("app.R")
+    test_that("module works", {
+      testModule(myPlot, {
+        expect_true(TRUE)
+      })
+    })
   })
 })

--- a/168-supporting-r-dir/tests/testthat.R
+++ b/168-supporting-r-dir/tests/testthat.R
@@ -1,0 +1,25 @@
+library(testthat)
+library(shiny)
+library(withr)
+
+inc <- function(x) if (is.null(x)) 0 else x+1
+
+# TODO Determine the ideal way for module-reliant test code to load an app
+with_dir(shiny:::findApp(), {
+  local({
+    source("R/counter.R")
+    test_that("counter works", {
+      testModule(counter, {
+        expect_equal(count(), 0)
+        # Simulate button press. Action buttons are counters, but their initial
+        # value is NULL so that they don't cause reactivity without being
+        # pressed at least once.
+        # TODO Consider adding session$click() or similar to mock session
+        session$setInputs(button = inc(input$button))
+        expect_equal(count(), 1)
+        expect_equal(output$out, "1")
+        expect_equal(session$returned(), 1)
+      })
+    })
+  })
+})

--- a/168-supporting-r-dir/tests/testthat.R
+++ b/168-supporting-r-dir/tests/testthat.R
@@ -1,25 +1,4 @@
 library(testthat)
 library(shiny)
-library(withr)
 
-inc <- function(x) if (is.null(x)) 0 else x+1
-
-# TODO Determine the ideal way for module-reliant test code to load an app
-with_dir(shiny:::findApp(), {
-  local({
-    source("R/counter.R")
-    test_that("counter works", {
-      testModule(counter, {
-        expect_equal(count(), 0)
-        # Simulate button press. Action buttons are counters, but their initial
-        # value is NULL so that they don't cause reactivity without being
-        # pressed at least once.
-        # TODO Consider adding session$click() or similar to mock session
-        session$setInputs(button = inc(input$button))
-        expect_equal(count(), 1)
-        expect_equal(output$out, "1")
-        expect_equal(session$returned(), 1)
-      })
-    })
-  })
-})
+testthat::test_file("testthat/tests.R")

--- a/168-supporting-r-dir/tests/testthat.R
+++ b/168-supporting-r-dir/tests/testthat.R
@@ -1,4 +1,8 @@
 library(testthat)
 library(shiny)
 
-testthat::test_file("testthat/tests.R")
+# We explicitly pass environment() here because shiny::runTests() has sourced
+# the files in R/, and the module we're testing was defined in those files. If
+# we don't specify env, testthat uses an environment that doesn't include the
+# module, and the tests fail.
+testthat::test_file("testthat/tests.R", env = environment())

--- a/168-supporting-r-dir/tests/testthat/tests.R
+++ b/168-supporting-r-dir/tests/testthat/tests.R
@@ -1,0 +1,13 @@
+library(testthat)
+library(shiny)
+
+test_that("counter works", {
+  testModule(counter, {
+    inc <- function(x) if (is.null(x)) 0 else x+1
+    expect_equal(count(), 0)
+    session$setInputs(button = inc(input$button))
+    expect_equal(count(), 1)
+    expect_equal(output$out, "1")
+    expect_equal(session$returned(), 1)
+  })
+})


### PR DESCRIPTION
This adds `testthat`-based unit/integration tests to 5 applications that would be exercised by the testthat action in https://github.com/rstudio/shinycoreci/pull/8

The most important lesson I learned was probably that in order for modules to be available in the test environment, it's important to provide the `env` argument to `testthat::test_file()`. Otherwise, `testthat` loads test files in a clean environment without the definitions added to the environment by `shiny::runTests()`.

It also occurred to me to add a first-class way to "click" an actionButton(); I created https://github.com/rstudio/shiny/issues/2745 to track this.

I ran across what I think is a bug in `shiny::runTests()`: https://github.com/rstudio/shiny/issues/2746

Overall, I had some difficulty adding what I would consider to be "helpful" tests. 