### PR TITLE
schedule all ci tests to run every work night at ~ midnight central

### DIFF
--- a/.github/workflows/ci-shinyjster.yml
+++ b/.github/workflows/ci-shinyjster.yml
@@ -8,7 +8,7 @@ on:
       - master
   # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#onschedule
   schedule:
-    - cron:  '0 0 * * 1' # every monday at midnight
+    - cron:  '0 6 * * 0-4' # every work night at ~ midnight central time
   repository_dispatch:
     types:
       - all

--- a/.github/workflows/ci-shinytest.yml
+++ b/.github/workflows/ci-shinytest.yml
@@ -10,7 +10,7 @@ on:
       - master
   # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#onschedule
   schedule:
-    - cron:  '0 0 * * 1' # every monday at midnight
+    - cron:  '0 6 * * 0-4' # every work night at ~ midnight central time
   repository_dispatch:
     types:
       - all

--- a/.github/workflows/ci-testthat.yml
+++ b/.github/workflows/ci-testthat.yml
@@ -10,7 +10,7 @@ on:
       - master
   # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#onschedule
   schedule:
-    - cron:  '0 0 * * 1' # every monday at midnight
+    - cron:  '0 6 * * 0-4' # every work night at ~ midnight central time
   repository_dispatch:
     types:
       - all


### PR DESCRIPTION
Should be merged once editing the testing apps has calmed down