### PR TITLE
add manual flags and remove 156-subapps/_shinyjster.R

### DIFF
--- a/.github/workflows/ci-shinyjster.yml
+++ b/.github/workflows/ci-shinyjster.yml
@@ -104,7 +104,8 @@ jobs:
 
       - name: shinyjster - Microsoft Edge
         # if: always() && (runner.os == 'Windows' || runner.os == 'macOS')
-        if: always() && runner.os == 'Windows'
+        # if: always() && runner.os == 'Windows'
+        if: false # current selenium can't find v80 edge
         timeout-minutes: 45
         shell: bash
         run: >

--- a/.github/workflows/ci-shinytest.yml
+++ b/.github/workflows/ci-shinytest.yml
@@ -168,8 +168,8 @@ jobs:
           git log -n 4 --pretty=oneline --simplify-by-decoration
 
           # if any commits occured, then push to repo (compare to sha of current execution)
-          echo "`git rev-list --count HEAD ^${{ github.sha }}`"
-          if (( `git rev-list --count HEAD ^${{ github.sha }}` > 0 )); then
+          echo "`git rev-list --count HEAD ^${{ steps.short_sha.outputs.sha }}`"
+          if (( `git rev-list --count HEAD ^${{ steps.short_sha.outputs.sha }}` > 0 )); then
             git push --force https://schloerke:${{secrets.GITHUB_PAT}}@github.com/rstudio/shinycoreci-apps.git "HEAD:$BRANCH"
           fi
 

--- a/apps/001-hello/app.R
+++ b/apps/001-hello/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 library(shiny)
 
 # Define UI for app that draws a histogram ----

--- a/apps/005-sliders/app.R
+++ b/apps/005-sliders/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 library(shiny)
 
 # Define UI for slider demo app ----

--- a/apps/019-mathjax/server.R
+++ b/apps/019-mathjax/server.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 function(input, output, session) {
   output$ex1 <- renderUI({
     withMathJax(helpText('Dynamic output 1:  $$\\alpha^2$$'))

--- a/apps/022-unicode-chinese/server.R
+++ b/apps/022-unicode-chinese/server.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 library(datasets)
 
 # 定义服务器逻辑

--- a/apps/051-movie-explorer/server.R
+++ b/apps/051-movie-explorer/server.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 library(ggvis)
 library(dplyr)
 if (FALSE) {

--- a/apps/063-superzip-example/server.R
+++ b/apps/063-superzip-example/server.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 library(leaflet)
 library(RColorBrewer)
 library(scales)

--- a/apps/081-widgets-gallery/server.R
+++ b/apps/081-widgets-gallery/server.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 function(input, output) {
 
   output$actionOut <- renderPrint({ input$action })

--- a/apps/082-word-cloud/server.R
+++ b/apps/082-word-cloud/server.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 # Text of the books downloaded from:
 # A Mid Summer Night's Dream:
 #  http://www.gutenberg.org/cache/epub/2242/pg2242.txt

--- a/apps/093-plot-interaction-basic/app.R
+++ b/apps/093-plot-interaction-basic/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 library(ggplot2)
 
 ui <- fluidPage(

--- a/apps/094-image-interaction-basic/app.R
+++ b/apps/094-image-interaction-basic/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 library(png)
 
 ui <- fluidPage(

--- a/apps/095-plot-interaction-advanced/app.R
+++ b/apps/095-plot-interaction-advanced/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 library(ggplot2)
 library(DT)
 

--- a/apps/096-plot-interaction-article-1/app.R
+++ b/apps/096-plot-interaction-article-1/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 library(shiny)
 
 ui <- basicPage(

--- a/apps/097-plot-interaction-article-2/app.R
+++ b/apps/097-plot-interaction-article-2/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 ui <- basicPage(
   plotOutput("plot1",
     click = "plot_click",

--- a/apps/098-plot-interaction-article-3/app.R
+++ b/apps/098-plot-interaction-article-3/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 ui <- basicPage(
   plotOutput("plot1", click = "plot_click"),
   verbatimTextOutput("info")

--- a/apps/099-plot-interaction-article-4/app.R
+++ b/apps/099-plot-interaction-article-4/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 library(ggplot2)
 ui <- basicPage(
   plotOutput("plot1", click = "plot_click"),

--- a/apps/100-plot-interaction-article-5/app.R
+++ b/apps/100-plot-interaction-article-5/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 ui <- basicPage(
   plotOutput("plot1", brush = "plot_brush"),
   verbatimTextOutput("info")

--- a/apps/101-plot-interaction-article-6/app.R
+++ b/apps/101-plot-interaction-article-6/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 library(ggplot2)
 ui <- basicPage(
   plotOutput("plot1", brush = "plot_brush", height = 250),

--- a/apps/102-plot-interaction-article-7/app.R
+++ b/apps/102-plot-interaction-article-7/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 library(ggplot2)
 ui <- basicPage(
   plotOutput("plot1", brush = "plot_brush"),

--- a/apps/103-plot-interaction-article-8/app.R
+++ b/apps/103-plot-interaction-article-8/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 library(ggplot2)
 ui <- basicPage(
   plotOutput("plot1",

--- a/apps/104-plot-interaction-select/app.R
+++ b/apps/104-plot-interaction-select/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 library(ggplot2)
 
 # We'll use a subset of the mtcars data set, with fewer columns

--- a/apps/105-plot-interaction-zoom/app.R
+++ b/apps/105-plot-interaction-zoom/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 library(ggplot2)
 
 ui <- fluidPage(

--- a/apps/106-plot-interaction-exclude/app.R
+++ b/apps/106-plot-interaction-exclude/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 library(ggplot2)
 
 ui <- fluidPage(

--- a/apps/108-module-output/app.R
+++ b/apps/108-module-output/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 library(shiny)
 
 source("linked_scatter.R")

--- a/apps/117-shinythemes/app.R
+++ b/apps/117-shinythemes/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 shinyApp(
   ui = tagList(
     shinythemes::themeSelector(),

--- a/apps/133-async-hold-inputs/app.R
+++ b/apps/133-async-hold-inputs/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 library(shiny)
 library(promises)
 library(later)

--- a/apps/135-bookmark-uioutput/app.R
+++ b/apps/135-bookmark-uioutput/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 library(promises)
 library(shiny)
 

--- a/apps/136-plot-cache/app.R
+++ b/apps/136-plot-cache/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 shinyApp(
 
   fluidPage(

--- a/apps/137-plot-cache-key/app.R
+++ b/apps/137-plot-cache-key/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 library(shiny)
 dataset <- reactiveVal(data.frame(x = rnorm(400), y = rnorm(400)))
 

--- a/apps/140-selectize-inputs/app.R
+++ b/apps/140-selectize-inputs/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 library(shiny)
 
 bigvec <- paste0("a", 1:1e5)

--- a/apps/141-radiant/app.R
+++ b/apps/141-radiant/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 ## CRAN
 # install.packages("radiant")
 

--- a/apps/154-index-html-server-r/tests/shinytest/mytest-expected-mac/001.json
+++ b/apps/154-index-html-server-r/tests/shinytest/mytest-expected-mac/001.json
@@ -8,9 +8,9 @@
       "deps": [
         {
           "name": "shinyjster-assets",
-          "version": "0.0.0.9008",
+          "version": "0.0.0.9009",
           "src": {
-            "href": "shinyjster-assets-0.0.0.9008"
+            "href": "shinyjster-assets-0.0.0.9009"
           },
           "meta": null,
           "script": "js/shinyjster.js",

--- a/apps/154-index-html-server-r/tests/shinytest/mytest-expected-win/001.json
+++ b/apps/154-index-html-server-r/tests/shinytest/mytest-expected-win/001.json
@@ -8,9 +8,9 @@
       "deps": [
         {
           "name": "shinyjster-assets",
-          "version": "0.0.0.9008",
+          "version": "0.0.0.9009",
           "src": {
-            "href": "shinyjster-assets-0.0.0.9008"
+            "href": "shinyjster-assets-0.0.0.9009"
           },
           "meta": null,
           "script": "js/shinyjster.js",

--- a/apps/155-index-html-app-r/tests/shinytest/mytest-expected-mac/001.json
+++ b/apps/155-index-html-app-r/tests/shinytest/mytest-expected-mac/001.json
@@ -8,9 +8,9 @@
       "deps": [
         {
           "name": "shinyjster-assets",
-          "version": "0.0.0.9008",
+          "version": "0.0.0.9009",
           "src": {
-            "href": "shinyjster-assets-0.0.0.9008"
+            "href": "shinyjster-assets-0.0.0.9009"
           },
           "meta": null,
           "script": "js/shinyjster.js",

--- a/apps/155-index-html-app-r/tests/shinytest/mytest-expected-win/001.json
+++ b/apps/155-index-html-app-r/tests/shinytest/mytest-expected-win/001.json
@@ -8,9 +8,9 @@
       "deps": [
         {
           "name": "shinyjster-assets",
-          "version": "0.0.0.9008",
+          "version": "0.0.0.9009",
           "src": {
-            "href": "shinyjster-assets-0.0.0.9008"
+            "href": "shinyjster-assets-0.0.0.9009"
           },
           "meta": null,
           "script": "js/shinyjster.js",

--- a/apps/156-subapps/_shinyjster.R
+++ b/apps/156-subapps/_shinyjster.R
@@ -1,7 +1,0 @@
-
-function(app, ...) {
-  shinyjster::run_jster(
-    appDir = file.path(app, "index.Rmd"),
-    ...
-  )
-}

--- a/apps/156-subapps/index.Rmd
+++ b/apps/156-subapps/index.Rmd
@@ -1,6 +1,4 @@
-### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
-
-
+<!-- ### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app -->
 ---
 title: "Subapp test"
 output: html_document

--- a/apps/156-subapps/index.Rmd
+++ b/apps/156-subapps/index.Rmd
@@ -1,5 +1,5 @@
-<!-- ### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app -->
 ---
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
 title: "Subapp test"
 output: html_document
 runtime: shiny

--- a/apps/156-subapps/index.Rmd
+++ b/apps/156-subapps/index.Rmd
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 ---
 title: "Subapp test"
 output: html_document

--- a/apps/156-subapps/tests/shinytest/mytest-expected-mac/001.json
+++ b/apps/156-subapps/tests/shinytest/mytest-expected-mac/001.json
@@ -70,9 +70,9 @@
         },
         {
           "name": "shinyjster-assets",
-          "version": "0.0.0.9008",
+          "version": "0.0.0.9009",
           "src": {
-            "href": "shinyjster-assets-0.0.0.9008"
+            "href": "shinyjster-assets-0.0.0.9009"
           },
           "meta": null,
           "script": "js/shinyjster.js",

--- a/apps/156-subapps/tests/shinytest/mytest-expected-win/001.json
+++ b/apps/156-subapps/tests/shinytest/mytest-expected-win/001.json
@@ -70,9 +70,9 @@
         },
         {
           "name": "shinyjster-assets",
-          "version": "0.0.0.9008",
+          "version": "0.0.0.9009",
           "src": {
-            "href": "shinyjster-assets-0.0.0.9008"
+            "href": "shinyjster-assets-0.0.0.9009"
           },
           "meta": null,
           "script": "js/shinyjster.js",

--- a/apps/161-discrete-limits/app.R
+++ b/apps/161-discrete-limits/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 library(shiny)
 library(ggplot2)
 library(dplyr)

--- a/apps/162-plot-dragging/app.R
+++ b/apps/162-plot-dragging/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 # Generate a png for renderImage
 image_file <- tempfile(fileext='.png')
 png(image_file, width=250, height=250)

--- a/apps/166-dynamic-hosted-tab/app.R
+++ b/apps/166-dynamic-hosted-tab/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 
 # devtools::install_github("rstudio/shiny#2545")
 # devtools::install_github("rstudio/shiny")

--- a/apps/167-resource-warnings/app.R
+++ b/apps/167-resource-warnings/app.R
@@ -1,3 +1,6 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
+
 library(shiny)
 
 addResourcePath("session", system.file(package = "httpuv"))


### PR DESCRIPTION
Related https://github.com/rstudio/shinycoreci/pull/25

https://github.com/schloerke/shinyjster/pull/32 allows for `shinyjster::run_jster("156-subapps")` with `156-subapps/index.Rmd`.

35 apps are flagged to be manually tested

Questions on apps:
- [x] Where is the `140-comprehensive-selectize` app?
  * To be removed
- [x] May we not manually test `169-prerender` as it is difficult to execute?
  * Must provide a script that can be run locally.
  * `shinycoreci::test_shinyjster(apps = "169-prerender")`

I don’t mind making an extra testing function to test app `169-prerender` using `shinyjster` (for non-hosted locations, ex: cloud / IDE / RSP), but `169-prerender` can not be tested on deployed locations.