### PR TITLE
Update for new testServer() behavior

### DIFF
--- a/apps/168-supporting-r-dir/tests/testthat.R
+++ b/apps/168-supporting-r-dir/tests/testthat.R
@@ -5,4 +5,10 @@ library(shiny)
 # the files in R/, and the module we're testing was defined in those files. If
 # we don't specify env, testthat uses an environment that doesn't include the
 # module, and the tests fail.
-testthat::test_file("testthat/tests.R", env = environment())
+testthat::test_dir(
+  "testthat/",
+  env = environment(),
+  # Ensure that errors propagate out to runTests(), which is generally how app
+  # tests should be exercised.
+  stop_on_failure = TRUE
+)

--- a/apps/168-supporting-r-dir/tests/testthat/tests.R
+++ b/apps/168-supporting-r-dir/tests/testthat/tests.R
@@ -2,7 +2,7 @@ library(testthat)
 library(shiny)
 
 test_that("counter works", {
-  testModule(counter, {
+  testServer(counterServer, {
     inc <- function(x) if (is.null(x)) 0 else x+1
     expect_equal(count(), 0)
     session$setInputs(button = inc(input$button))


### PR DESCRIPTION
This updates app 168 so that it doesn't use `testModule()`, which has been removed from Shiny master in favor of a more capable `testServer()`.

I also modified the testthat configuration so that failing unit tests will signal an error instead of merely printing a summary.