### PR TITLE
Add flags to apps to not test

### DIFF
--- a/.github/workflows/ci-shinyjster.yml
+++ b/.github/workflows/ci-shinyjster.yml
@@ -28,9 +28,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        # - { os: macOS-latest, r: '3.6', cran: "https://cloud.r-project.org"}
+        - { os: macOS-latest, r: '3.6', cran: "https://cloud.r-project.org"}
         - { os: windows-latest, r: '3.6', cran: "https://cloud.r-project.org"}
-        # - { os: ubuntu-16.04, r: '3.6', cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+        - { os: ubuntu-16.04, r: '3.6', cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
     runs-on: ${{ matrix.config.os }}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
@@ -114,8 +114,8 @@ jobs:
           -e "shinycoreci::test_shinyjster(browser = 'edge')"
 
       - name: shinyjster - Google Chrome
-        # if: always()
-        if: false
+        if: always()
+        # if: false
         timeout-minutes: 45
         shell: bash
         run: >
@@ -123,8 +123,8 @@ jobs:
           -e "shinycoreci::test_shinyjster(browser = 'chrome')"
 
       - name: shinyjster - Firefox
-        # if: always()
-        if: false
+        if: always()
+        # if: false
         timeout-minutes: 45
         shell: bash
         run: >

--- a/.github/workflows/ci-shinyjster.yml
+++ b/.github/workflows/ci-shinyjster.yml
@@ -4,7 +4,6 @@ on:
       - master
       - jster
       - shinyjster
-      - ie_hanging
       - ghactions
   pull_request:
     branches:

--- a/.github/workflows/ci-shinyjster.yml
+++ b/.github/workflows/ci-shinyjster.yml
@@ -101,7 +101,7 @@ jobs:
         shell: bash
         run: >
           Rscript
-          -e "shinycoreci::test_shinyjster(browser = 'ie', apps = sample(shinycoreci::apps_shinyjster('apps')))"
+          -e "shinycoreci::test_shinyjster(browser = 'ie')"
 
       - name: shinyjster - Microsoft Edge
         # if: always() && (runner.os == 'Windows' || runner.os == 'macOS')

--- a/apps/022-unicode-chinese/tests/shinytest.R
+++ b/apps/022-unicode-chinese/tests/shinytest.R
@@ -1,2 +1,4 @@
+### Keep this line to NOT test this shiny application with shinycoreci::test_shinytest on Windows. Do not edit this line; shinycoreci::::not_shinytest_app_win
+
 library(shinytest)
 shinytest::testApp("../")

--- a/apps/124-async-download/app.R
+++ b/apps/124-async-download/app.R
@@ -1,3 +1,5 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
 library(shiny)
 library(promises)
 library(future)

--- a/apps/124-async-download/tests/shinytest.R
+++ b/apps/124-async-download/tests/shinytest.R
@@ -1,3 +1,4 @@
+### Keep this line to NOT test this shiny application with shinycoreci::test_shinytest on Mac. Do not edit this line; shinycoreci::::not_shinytest_app_mac
+
 library(shinytest)
 shinytest::testApp("../")
-

--- a/apps/156-subapps/index.Rmd
+++ b/apps/156-subapps/index.Rmd
@@ -1,5 +1,6 @@
 ---
 ### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+### Keep this line to NOT test this shiny application with shinycoreci::test_shinyjster with IE. Do not edit this line; shinycoreci::::not_jster_app_ie
 title: "Subapp test"
 output: html_document
 runtime: shiny


### PR DESCRIPTION
Related: https://github.com/rstudio/shinycoreci/commit/e6158a789ec1901a9f0f14693e20b304072380b6

* 022 - no shinytest on windows
* 124 - no shinytest on mac
* 124 - make a manual app
* 156 - no shinyjster on IE
