### PR TITLE
Update 082-word-cloud blogpost link that works

### DIFF
--- a/apps/082-word-cloud/README.md
+++ b/apps/082-word-cloud/README.md
@@ -1,1 +1,1 @@
-A simple word cloud generator, based on [this blog post](http://pirategrunt.com/2013/12/11/24-days-of-r-day-11/) by PirateGrunt.
+A simple word cloud generator, based on [this blog post](https://pirategrunt.wordpress.com/2013/12/11/24-days-of-r-day-11/) by PirateGrunt.


### PR DESCRIPTION
Existing link of the blogpost reference does not work. Updated it.