### PR TITLE
Fix setting path in Windows

### DIFF
--- a/.github/workflows/ci-runtests.yml
+++ b/.github/workflows/ci-runtests.yml
@@ -451,7 +451,7 @@ jobs:
         # C:/Rtools/bin/tar.exe, it will say that it can't find gzip.exe. So
         # we'll just set the path so that the original tar that would be
         # found, will be found.
-        run: echo "::add-path::C:/Program Files/Git/usr/bin"
+        run: echo "C:/Program Files/Git/usr/bin" >> $GITHUB_PATH
 
       - name: Notify slack SUCCESS
         if: success()


### PR DESCRIPTION
This is an attempt to fix the path for caching on Windows.

Using the method described here:
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#adding-a-system-path