### PR TITLE
Fix docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Docker
 on:
   push:
     branches:
-      - docker
+      - docker**
       - ghactions
   # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#onschedule
   schedule:

--- a/Docker/centos/Dockerfile
+++ b/Docker/centos/Dockerfile
@@ -121,6 +121,8 @@ RUN yum install -y freetype-devel libpng-devel libtiff-devel
 RUN R --quiet -e "system(print(shinycoreci::rspm_all_install_scripts('~/apps', release = '${RELEASE}')))"
 
 # install r pkgs
+## install htmltools to get dev version
+RUN R --quiet -e "remotes::install_github('rstudio/htmltools', auth_token ='${GITHUB_PAT}')"
 RUN R --quiet -e "shinycoreci:::update_packages_installed('~/apps')"
 
 

--- a/Docker/centos/Dockerfile
+++ b/Docker/centos/Dockerfile
@@ -86,11 +86,10 @@ ENV GITHUB_PAT=$GITHUB_PAT
 
 # prep install
 RUN R --quiet -e "install.packages('remotes')"
+RUN R --quiet -e "remotes::install_cran(c('knitr', 'rmarkdown', 'curl'))"
 RUN R --quiet -e "remotes::install_cran(c('shinytest'))"
 # some how this package isn't a dep, but is required for a package
 RUN R --quiet -e "remotes::install_cran(c('markdown'))"
-# shinycoreci deps
-RUN R --quiet -e "remotes::install_cran(c('sessioninfo', 'renv', 'remotes', 'shinytest', 'shiny', 'htmltools', 'httpuv', 'promises', 'later', 'htmlwidgets', 'reactlog', 'fastmap', 'websocket', 'plotly', 'leaflet', 'leaflet.providers', 'crosstalk', 'flexdashboard', 'pool', 'curl', 'jsonlite', 'callr', 'progress', 'rsconnect', 'httr'))"
 
 ARG SHINYCORECI_SHA=master
 ARG APPS_SHA=master

--- a/Docker/ubuntu/Dockerfile
+++ b/Docker/ubuntu/Dockerfile
@@ -116,6 +116,7 @@ ENV GITHUB_PAT=$GITHUB_PAT
 
 # prep install
 RUN R --quiet -e "install.packages('remotes')"
+RUN R --quiet -e "remotes::install_cran(c('knitr', 'rmarkdown', 'curl'))"
 RUN R --quiet -e "remotes::install_cran(c('shinytest'))"
 
 ARG SHINYCORECI_SHA=master

--- a/Docker/ubuntu/Dockerfile
+++ b/Docker/ubuntu/Dockerfile
@@ -151,6 +151,8 @@ RUN apt-get update && apt-get install -y \
 # Must use `~/apps` as default working directory is not `~`
 RUN R --quiet -e "system(print(shinycoreci::rspm_all_install_scripts('~/apps', release = '${RELEASE}')))"
 # install r pkgs
+## install htmltools to get dev version
+RUN R --quiet -e "remotes::install_github('rstudio/htmltools', auth_token ='${GITHUB_PAT}')"
 RUN R --quiet -e "shinycoreci:::update_packages_installed('~/apps')"
 
 


### PR DESCRIPTION
* only install knitr, rmarkdown, and curl for rspm to be used
* install htmltools to avoid a "already loaded CRAN version" issue.