### PR TITLE
Update 205-dynamic-tabs-compat to use insertTab() correctly

### DIFF
--- a/apps/205-dynamic-tabs-compat/app.R
+++ b/apps/205-dynamic-tabs-compat/app.R
@@ -38,7 +38,8 @@ btn_server <- function(id, navId = id) {
           "-----",
           tabPanel("B", "B- content")
         ),
-        target = NULL
+        target = NULL,
+        position = "after"
       )
     })
 


### PR DESCRIPTION
Turns out `205-dynamic-tabs-compat` was relying on a bug in `insertTab(target = NULL)` that has since been fixed https://github.com/rstudio/shiny/blame/master/NEWS.md#L10 