### PR TITLE
Adjustment to 213

### DIFF
--- a/apps/213-tab-panels/app.R
+++ b/apps/213-tab-panels/app.R
@@ -33,7 +33,8 @@ server <- function(input, output, session) {
     insertTab(
       inputId = "tabs",
       tabPanel(id, id),
-      target = "s2"
+      target = "s2",
+      position = "before"
     )
   })
   observeEvent(input$removeFoo, {


### PR DESCRIPTION
The dev version of shiny changes `insertTab()` to `position="after"`. By specifying `position="before"`, this should fix any differences in behavior