### PR TITLE
Hard code mac release on R v4.1.0

### DIFF
--- a/.github/workflows/ci-runtests.yml
+++ b/.github/workflows/ci-runtests.yml
@@ -239,9 +239,9 @@ jobs:
         - { os: ubuntu-18.04, rspm: "https://packagemanager.rstudio.com/all/__linux__/bionic/latest", release: bionic }
         ## Temp fix to test mac on 4.1.0
         include:
-        - { config: { os: macOS-latest }, r: "4.1.0", shinycoreci: {branch: "master", text:""} }
+        - { config: { os: "macOS-latest" }, r: "4.1.0", shinycoreci: {branch: "master", text:""} }
         exclude:
-        - { config: { os: macOS-latest }, r: "4.1.1", shinycoreci: {branch: "master", text:""} }
+        - { config: { os: "macOS-latest" }, r: "4.1.1", shinycoreci: {branch: "master", text:""} }
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}

--- a/.github/workflows/ci-runtests.yml
+++ b/.github/workflows/ci-runtests.yml
@@ -239,9 +239,21 @@ jobs:
         - { os: ubuntu-18.04, rspm: "https://packagemanager.rstudio.com/all/__linux__/bionic/latest", release: bionic }
         ## Temp fix to test mac on 4.1.0
         include:
-        - { config: { os: "macOS-latest" }, r: "4.1.0", shinycoreci: {branch: "master", text:""} }
+        - 
+          config: 
+            os: "macOS-latest"
+          r: "4.1.0"
+          shinycoreci:
+            branch: "master"
+            text: ""
         exclude:
-        - { config: { os: "macOS-latest" }, r: "4.1.1", shinycoreci: {branch: "master", text:""} }
+        - 
+          config: 
+            os: "macOS-latest"
+          r: "4.1.1"
+          shinycoreci:
+            branch: "master"
+            text: ""
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}

--- a/.github/workflows/ci-runtests.yml
+++ b/.github/workflows/ci-runtests.yml
@@ -237,6 +237,11 @@ jobs:
         - { os: macOS-latest }
         - { os: windows-latest }
         - { os: ubuntu-18.04, rspm: "https://packagemanager.rstudio.com/all/__linux__/bionic/latest", release: bionic }
+        ## Temp fix to test mac on 4.1.0
+        include:
+        - { config: { os: macOS-latest }, r: "4.1.0", shinycoreci: {branch: "master", text:""} }
+        exclude:
+        - { config: { os: macOS-latest }, r: "4.1.1", shinycoreci: {branch: "master", text:""} }
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}

--- a/apps/001-hello/app.R
+++ b/apps/001-hello/app.R
@@ -83,5 +83,6 @@ server <- function(input, output, session) {
 
 }
 
+
 # Create Shiny app ----
 shinyApp(ui = ui, server = server)


### PR DESCRIPTION
* temporarily add macOS R 4.1.0 into the test matrix
* temporarily remove macOS R 4.1.1 from the test matrix

Ex: 
![Screen Shot 2021-08-11 at 2 36 49 PM](https://user-images.githubusercontent.com/93231/129084545-5972aedf-57bf-4e07-9db1-8f9aad5ec455.png)
