### PR TITLE
Revert "Hard code mac release on R v4.1.0 (#177)"

### DIFF
--- a/.github/workflows/ci-runtests.yml
+++ b/.github/workflows/ci-runtests.yml
@@ -237,23 +237,6 @@ jobs:
         - { os: macOS-latest }
         - { os: windows-latest }
         - { os: ubuntu-18.04, rspm: "https://packagemanager.rstudio.com/all/__linux__/bionic/latest", release: bionic }
-        ## Temp fix to test mac on 4.1.0
-        include:
-        - 
-          config: 
-            os: "macOS-latest"
-          r: "4.1.0"
-          shinycoreci:
-            branch: "master"
-            text: ""
-        exclude:
-        - 
-          config: 
-            os: "macOS-latest"
-          r: "4.1.1"
-          shinycoreci:
-            branch: "master"
-            text: ""
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}

--- a/apps/001-hello/app.R
+++ b/apps/001-hello/app.R
@@ -83,6 +83,5 @@ server <- function(input, output, session) {
 
 }
 
-
 # Create Shiny app ----
 shinyApp(ui = ui, server = server)


### PR DESCRIPTION
This reverts commit 5c43d94ce15c1f78caec3da9b0c961c0b8cab9ac.

`R-4.1.1.pkg` exists in https://cloud.r-project.org/bin/macosx/

![Screen Shot 2021-08-12 at 3 02 21 PM](https://user-images.githubusercontent.com/93231/129253770-5061ed1e-57fe-4730-83cb-db57685887b5.png)
